### PR TITLE
fix: language not found error if wrong parameter pass to localProvider

### DIFF
--- a/.changeset/calm-cooks-hug.md
+++ b/.changeset/calm-cooks-hug.md
@@ -1,0 +1,5 @@
+---
+'@kubed/components': patch
+---
+
+1. fix language not found error if wrong parameter pass to localProvider

--- a/packages/components/src/ConfigProvider/LocaleProvider/LocaleProvider.tsx
+++ b/packages/components/src/ConfigProvider/LocaleProvider/LocaleProvider.tsx
@@ -9,12 +9,14 @@ export interface Props {
   extendLocales?: Record<Locale, ILocale>;
 }
 
+const localeKeys = ['en', 'zh', 'zh-tw', 'es'];
+
 function LocaleProvider({ children, locale, extendLocales }: PropsWithChildren<Props>) {
   const [currentLocale, setCurrentLocale] = useState<Locale>('en');
   const mergedLocales = merge(locales, extendLocales);
 
   useEffect(() => {
-    if (!locale) return;
+    if (!locale || !localeKeys.includes(locale)) return;
     setCurrentLocale(locale);
   }, [locale]);
 


### PR DESCRIPTION
Signed-off-by: chenz24 <wayne@kubesphere.io>